### PR TITLE
Fix invisible thrusters on load

### DIFF
--- a/build/r6/scripts/let_there_be_flight.reds
+++ b/build/r6/scripts/let_there_be_flight.reds
@@ -381,11 +381,6 @@ public class FlightComponent extends ScriptableDeviceComponent {
     } else {
       // FlightLog.Info("[FlightComponent] OnMountingEvent for other vehicle: " + this.GetVehicle().GetDisplayName());
     }
-    let normal: Vector4;
-    this.SetupTires();
-    if !this.FindGround(normal) || this.distance > 1.0 {
-      this.Activate();
-    }
   }
   
   protected cb func OnVehicleFinishedMountingEvent(evt: ref<VehicleFinishedMountingEvent>) -> Bool {
@@ -398,6 +393,11 @@ public class FlightComponent extends ScriptableDeviceComponent {
         //this.sys.audio.Play("vehicle3_on");
         // this.sys.audio.StartWithPitch("playerVehicle", "vehicle3_TPP", this.GetPitch());
       }
+    }
+    let normal: Vector4;
+    this.SetupTires();
+    if !this.FindGround(normal) || this.distance > 1.0 {
+      this.Activate();
     }
   }
 

--- a/src/redscript/let_there_be_flight/FlightComponent.reds
+++ b/src/redscript/let_there_be_flight/FlightComponent.reds
@@ -200,11 +200,6 @@ public class FlightComponent extends ScriptableDeviceComponent {
     } else {
       // FlightLog.Info("[FlightComponent] OnMountingEvent for other vehicle: " + this.GetVehicle().GetDisplayName());
     }
-    let normal: Vector4;
-    this.SetupTires();
-    if !this.FindGround(normal) || this.distance > 1.0 {
-      this.Activate();
-    }
   }
   
   protected cb func OnVehicleFinishedMountingEvent(evt: ref<VehicleFinishedMountingEvent>) -> Bool {
@@ -217,6 +212,11 @@ public class FlightComponent extends ScriptableDeviceComponent {
         //this.sys.audio.Play("vehicle3_on");
         // this.sys.audio.StartWithPitch("playerVehicle", "vehicle3_TPP", this.GetPitch());
       }
+    }
+    let normal: Vector4;
+    this.SetupTires();
+    if !this.FindGround(normal) || this.distance > 1.0 {
+      this.Activate();
     }
   }
 


### PR DESCRIPTION
Loading into a hovering-state save, the thrusters on your current vehicle (and then all other vehicles) will be invisible. Moving the detection/activation block to OnVehicleFinishedMountingEvent seems to resolve the issue.