### PR TITLE
fix vehicle bunnyhopping when idle

### DIFF
--- a/build/r6/scripts/let_there_be_flight.reds
+++ b/build/r6/scripts/let_there_be_flight.reds
@@ -648,9 +648,15 @@ public class FlightComponent extends ScriptableDeviceComponent {
       force *= collisionDampener;
       this.collisionTimer += timeDelta;
     }
+    // only apply force if active - fixes bunnyhopping
+    if this.active { 
+      this.force += force;
+      this.torque += torque;
+    }else{
+      this.force =  Vector4.EmptyVector();
+      this.torque =  Vector4.EmptyVector();
+    }
 
-    this.force += force;
-    this.torque += torque;
   }
 
   protected cb func OnVehicleFlightDeactivationEvent(evt: ref<VehicleFlightDeactivationEvent>) -> Bool {


### PR DESCRIPTION
fix vehicles bunnyhopping/skipping forwards when idle after deactivation. 
I assume a closer inspection will reveal why the force is still being applied while inactive/disabled.